### PR TITLE
Add support for Darwin 23 setup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -141,7 +141,7 @@ while [ $# -gt 0 ]; do
 done
 mkdir -p /usr/local/opt/gridlabd || error "you do not have permission to create /usr/local/opt/gridlabd"
 autoconf --version 1>/dev/null 2>&1 || error "autoconf not installed. Did you run setup.sh?"
-test "$(autoconf --version 2>/dev/null | head -n 1 | grep -o '[^ ]*$')" '>' "2.70" || error "autoconf version 2.72 or later required. Did you run setup.sh?"
+test "$(autoconf --version 2>/dev/null | head -n 1 | grep -o '[^ ]*$')" '>' "2.72" || error "autoconf version 2.72 or later required. Did you run setup.sh?"
 git --version 1>/dev/null 2>&1 || error "you must install git to build GridLAB-D"
 test -f $SRCDIR/configure.ac || error "you must build from the source directory where configure.ac is located"
 test -f $HOME/.gridlabd/bin/activate || error "$HOME/.gridlabd is not found. Run setup.sh again."

--- a/build.sh
+++ b/build.sh
@@ -141,7 +141,7 @@ while [ $# -gt 0 ]; do
 done
 mkdir -p /usr/local/opt/gridlabd || error "you do not have permission to create /usr/local/opt/gridlabd"
 autoconf --version 1>/dev/null 2>&1 || error "autoconf not installed. Did you run setup.sh?"
-test "$(autoconf --version 2>/dev/null | head -n 1 | grep -o '[^ ]*$')" '>' "2.70" || error "autoconf version 2.71 or later required. Did you run setup.sh?"
+test "$(autoconf --version 2>/dev/null | head -n 1 | grep -o '[^ ]*$')" '>' "2.70" || error "autoconf version 2.72 or later required. Did you run setup.sh?"
 git --version 1>/dev/null 2>&1 || error "you must install git to build GridLAB-D"
 test -f $SRCDIR/configure.ac || error "you must build from the source directory where configure.ac is located"
 test -f $HOME/.gridlabd/bin/activate || error "$HOME/.gridlabd is not found. Run setup.sh again."

--- a/build.sh
+++ b/build.sh
@@ -141,7 +141,7 @@ while [ $# -gt 0 ]; do
 done
 mkdir -p /usr/local/opt/gridlabd || error "you do not have permission to create /usr/local/opt/gridlabd"
 autoconf --version 1>/dev/null 2>&1 || error "autoconf not installed. Did you run setup.sh?"
-test "$(autoconf --version 2>/dev/null | head -n 1 | grep -o '[^ ]*$')" '>' "2.72" || error "autoconf version 2.72 or later required. Did you run setup.sh?"
+test "$(autoconf --version 2>/dev/null | head -n 1 | grep -o '[^ ]*$')" '>' "2.71" || error "autoconf version 2.72 or later required. Did you run setup.sh?"
 git --version 1>/dev/null 2>&1 || error "you must install git to build GridLAB-D"
 test -f $SRCDIR/configure.ac || error "you must build from the source directory where configure.ac is located"
 test -f $HOME/.gridlabd/bin/activate || error "$HOME/.gridlabd is not found. Run setup.sh again."

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ m4_define([versionname], sbuild_m4_esyscmd_s([build-aux/version.sh --name]))
 m4_define([pkginstall], sbuild_m4_esyscmd_s([build-aux/version.sh --install]))
 m4_define([pkgorigin],sbuild_m4_esyscmd_s([git rev-parse --abbrev-ref HEAD]))
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.72])
 AC_INIT([pkgname],[pkgversion],[gridlabd@gmail.com],[pkg])
 AC_CONFIG_SRCDIR([source/gridlabd.h])
 AC_CONFIG_HEADERS([source/config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -527,6 +527,14 @@ AS_IF([test "x$MYSQL" != "xno"],
 
             # Define HAVE_MYSQL
             AC_DEFINE([HAVE_MYSQL], [1], [Define when you have MySQL])
+
+            # Add brew paths for Darwin systems
+            AS_CASE([$host_os],
+            [darwin*], [
+                BREW_PREFIX=$(brew --prefix)
+                MYSQL_LDFLAGS="$MYSQL_LDFLAGS -L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/lib"
+                MYSQL_CPPFLAGS="$MYSQL_CPPFLAGS -I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/include"
+            ])
     ],
     [HAVE_MYSQL=no])
 

--- a/setup/darwin_20.sh
+++ b/setup/darwin_20.sh
@@ -67,9 +67,9 @@ if ! mysql_config --libs >/dev/null 2>&1 ; then
     fi
 fi
 
-# install autoconf 2.71 as required
-if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.71" ] ; then
-    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.gz | tar xz )
-    (cd /tmp/autoconf-2.71 ; ./configure ; make ; make install)
-    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.71" || error "autoconf installation failed"
+# install autoconf 2.72 as required
+if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.72" ] ; then
+    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.gz | tar xz )
+    (cd /tmp/autoconf-2.72 ; ./configure ; make ; make install)
+    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.72" || error "autoconf installation failed"
 fi

--- a/setup/darwin_21.sh
+++ b/setup/darwin_21.sh
@@ -67,9 +67,9 @@ if ! mysql_config --libs >/dev/null 2>&1 ; then
     fi
 fi
 
-# install autoconf 2.71 as required
-if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.71" ] ; then
-    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.gz | tar xz )
-    (cd /tmp/autoconf-2.71 ; ./configure ; make ; make install)
-    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.71" || error "autoconf installation failed"
+# install autoconf 2.72 as required
+if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.72" ] ; then
+    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.gz | tar xz )
+    (cd /tmp/autoconf-2.72 ; ./configure ; make ; make install)
+    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.72" || error "autoconf installation failed"
 fi

--- a/setup/darwin_22.sh
+++ b/setup/darwin_22.sh
@@ -67,9 +67,9 @@ if ! mysql_config --libs >/dev/null 2>&1 ; then
     fi
 fi
 
-# install autoconf 2.71 as required
-if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.71" ] ; then
-    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.gz | tar xz )
-    (cd /tmp/autoconf-2.71 ; ./configure ; make ; make install)
-    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.71" || error "autoconf installation failed"
+# install autoconf 2.72 as required
+if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.72" ] ; then
+    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.gz | tar xz )
+    (cd /tmp/autoconf-2.72 ; ./configure ; make ; make install)
+    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.72" || error "autoconf installation failed"
 fi

--- a/setup/darwin_23.sh
+++ b/setup/darwin_23.sh
@@ -1,0 +1,75 @@
+set -x
+alias INSTALL=''
+
+INSTALL error () { echo "ERROR [darwin_23-x86_64.sh]: $*" > /dev/stderr ; exit 1 ; }
+INSTALL PYTHON_VERSION=3.10
+INSTALL PYTHON_VENV=${HOME:-/tmp}/.gridlabd
+INSTALL PYTHON_EXEC=$PYTHON_VENV/bin/python$PYTHON_VERSION
+INSTALL PYTHON_CONFIG=$PYTHON_VENV/bin/python${PYTHON_VERSION}-config
+
+# check for root access
+INSTALL test "$(whoami)" != "root" || error "you should not run setup.sh as root or use sudo"
+
+# prepare brew for installations
+INSTALL brew -h 1>/dev/null 2>&1 || error "you must install brew first. See https://brew.sh for details."
+
+# setup requires python version if not already installed
+if ! python$PYTHON_VERSION --version 1>/dev/null 2>&1 ; then
+    INSTALL brew install python@$PYTHON_VERSION
+    python$PYTHON_VERSION --version || error "python$PYTHON_VERSION installation failed"
+fi
+if ! python$PYTHON_VERSION -m venv -h 1>/dev/null 2>&1 ; then
+    printf "installing... "
+    INSTALL brew install python$PYTHON_VERSION-venv
+    python$PYTHON_VERSION -m venv -h >/dev/null || error "unable to install python$PYTHON_VERSION-venv"
+fi
+
+# create python venv for setup if not already done
+if [ ! -x "$PYTHON_EXEC" ] ; then
+    INSTALL python$PYTHON_VERSION -m venv $PYTHON_VENV
+    test -x "$PYTHON_EXEC" || error "python venv creation failed"
+fi
+
+# activate the build environment for python
+INSTALL . $PYTHON_VENV/bin/activate
+test ! -z "$VIRTUAL_ENV" || error "python venv activation failed"
+
+# upgrade pip if needed
+if ! "$PYTHON_EXEC" -m pip --version 1>/dev/null 2>&1 ; then
+    INSTALL curl -fsL https://bootstrap.pypa.io/get-pip.py | python$PYTHON_VERSION
+    INSTALL "$PYTHON_EXEC" -m pip --version || error "pip installation failed"
+fi
+
+# install python-config
+if ! "python$PYTHON_VERSION-config" --prefix 1>/dev/null 2>&1 ; then
+    INSTALL brew install python$PYTHON_VERSION-dev
+    python$PYTHON_VERSION-config --prefix || error "python$PYTHON_VERSION-config installation failed"
+fi
+INSTALL "$PYTHON_EXEC" -m pip install --upgrade pip || error "pip update failed"
+
+# install required libraries
+INSTALL brew install autoconf libffi zlib pkg-config xz gdbm tcl-tk
+
+# install required tools
+INSTALL brew install automake libtool gnu-sed gawk
+
+clang -v >/dev/null || error "you have not installed clang. Use 'xcode-select --install' to install command line build tools."
+
+# # update library paths
+# INSTALL ldconfig
+
+# install mysql
+if ! mysql_config --libs >/dev/null 2>&1 ; then
+    printf "Installing MySQL... "
+    brew install mysql
+    if ! mysql_config --libs >/dev/null 2>&1 ; then
+        error "Failed to install MySQL with Homebrew."
+    fi
+fi
+
+# install autoconf 2.71 as required
+if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.71" ] ; then
+    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.gz | tar xz )
+    (cd /tmp/autoconf-2.71 ; ./configure ; make ; make install)
+    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.71" || error "autoconf installation failed"
+fi

--- a/setup/darwin_23.sh
+++ b/setup/darwin_23.sh
@@ -1,7 +1,7 @@
 set -x
 alias INSTALL=''
 
-INSTALL error () { echo "ERROR [darwin_23-x86_64.sh]: $*" > /dev/stderr ; exit 1 ; }
+INSTALL error () { echo "ERROR [$(basename $0)]: $*" > /dev/stderr ; exit 1 ; }
 INSTALL PYTHON_VERSION=3.10
 INSTALL PYTHON_VENV=${HOME:-/tmp}/.gridlabd
 INSTALL PYTHON_EXEC=$PYTHON_VENV/bin/python$PYTHON_VERSION
@@ -67,9 +67,9 @@ if ! mysql_config --libs >/dev/null 2>&1 ; then
     fi
 fi
 
-# install autoconf 2.71 as required
-if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.71" ] ; then
-    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.gz | tar xz )
-    (cd /tmp/autoconf-2.71 ; ./configure ; make ; make install)
-    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.71" || error "autoconf installation failed"
+# install autoconf 2.72 as required
+if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.72" ] ; then
+    (cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.gz | tar xz )
+    (cd /tmp/autoconf-2.72 ; ./configure ; make ; make install)
+    test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.72" || error "autoconf installation failed"
 fi

--- a/setup/ubuntu_20.sh
+++ b/setup/ubuntu_20.sh
@@ -69,9 +69,9 @@ INSTALL ldconfig
 ln -s /usr/include/mysql /usr/local/include/mysql
 ln -s /usr/lib/aarch64-linux-gnu/libmysqlclient.a /usr/local/lib/libmysqlclient.a
 
-# install autoconf 2.71 as required
-if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.71" ] ; then
-	(cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.gz | tar xz )
-	(cd /tmp/autoconf-2.71 ; ./configure ; make ; make install)
-	test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.71" || error "autoconf installation failed"
+# install autoconf 2.72 as required
+if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.72" ] ; then
+	(cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.gz | tar xz )
+	(cd /tmp/autoconf-2.72 ; ./configure ; make ; make install)
+	test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.72" || error "autoconf installation failed"
 fi

--- a/setup/ubuntu_22.sh
+++ b/setup/ubuntu_22.sh
@@ -69,9 +69,9 @@ INSTALL ldconfig
 ln -s /usr/include/mysql /usr/local/include/mysql
 ln -s /usr/lib/aarch64-linux-gnu/libmysqlclient.a /usr/local/lib/libmysqlclient.a
 
-# install autoconf 2.71 as required
-if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.71" ] ; then
-	(cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.gz | tar xz )
-	(cd /tmp/autoconf-2.71 ; ./configure ; make ; make install)
-	test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.71" || error "autoconf installation failed"
+# install autoconf 2.72 as required
+if [ "$(autoconf --version | head -n 1 | cut -f4 -d' ')" != "2.72" ] ; then
+	(cd /tmp ; curl -sL https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.gz | tar xz )
+	(cd /tmp/autoconf-2.72 ; ./configure ; make ; make install)
+	test "$(autoconf --version | head -n 1 | cut -f4 -d' ')" = "2.72" || error "autoconf installation failed"
 fi


### PR DESCRIPTION
This PR addresses several issues:

- [x] Update autoconf installed version to be compatible with brew installed automake
- [x] Update configure.ac file to add mysql dependent library paths for darwin systems automatically using brew
- [x] Add darwin_23 setup script due to forced migrations to Sonoma