### PR TITLE
Develop actions runner

### DIFF
--- a/.github/workflows/develop-image.yml
+++ b/.github/workflows/develop-image.yml
@@ -149,7 +149,7 @@ jobs:
         sudo sh ./build.sh --upload --release
 
   buildAWSUbuntuAMI:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: Integration
     needs: [buildUbuntu22FastS3,buildUbuntu20FastS3,buildMacos12FastS3,buildMacos13FastS3]
 

--- a/.github/workflows/master-image.yml
+++ b/.github/workflows/master-image.yml
@@ -149,7 +149,7 @@ jobs:
         sudo sh ./build.sh --upload --release
 
   buildAWSUbuntuAMI:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: Integration
     needs: [buildUbuntu22FastS3,buildUbuntu20FastS3,buildMacos12FastS3]
 


### PR DESCRIPTION
This PR includes a version fix for the runner.

GHA now uses Ubuntu 24 for its ubuntu-latest runner, causing the script to look for a non-existent version and failing the run. Pinning the Dockerhub generation to Ubuntu 22. 