### PR TITLE
Fix obj name segfault on initialization

### DIFF
--- a/docs/Global/Initializeonly.md
+++ b/docs/Global/Initializeonly.md
@@ -5,24 +5,24 @@
 GLM:
 
 ~~~
-#set Initializeonly=FALSE
+#set initializeonly=FALSE
 ~~~
 
 Shell:
 
 ~~~
-bash$ gridlabd -D Initializeonly=FALSE
-bash$ gridlabd --define Initializeonly=FALSE
+bash$ gridlabd -D initializeonly=FALSE
+bash$ gridlabd --define initializeonly=FALSE
 ~~~
 
 # Description
 
-Initialize only enable flag
+Initialize only enable flag.
 
 # Example
 
 ~~~
-#set compileonly=FALSE
+#set initializeonly=FALSE
 ~~~
 
 # See also

--- a/module/powerflow/currdump.cpp
+++ b/module/powerflow/currdump.cpp
@@ -272,7 +272,7 @@ EXPORT int init_currdump(OBJECT *obj)
 	}
 	catch (const char *msg)
 	{
-		gl_error("%s (currdump:%d): %s", obj->name, obj->id, msg);
+		gl_error("%s (currdump:%d): %s", obj->name && strlen(obj->name) > 0 ? obj->name : "(na)", obj->id, msg);
 		return 0; 
 	}
 }

--- a/module/powerflow/impedance_dump.cpp
+++ b/module/powerflow/impedance_dump.cpp
@@ -122,7 +122,7 @@ int impedance_dump::dump(TIMESTAMP t)
 
 	//write style sheet info
 	fprintf(fn,"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
-	fprintf(fn,"<?xml-stylesheet href=\"C:\\Projects\\GridLAB-D_Builds\\ticket_704\\VS2005\\gridlabd-2_0.xsl\" type=\"text/xsl\"?>\n");
+	//fprintf(fn,"<?xml-stylesheet href=\"C:\\Projects\\GridLAB-D_Builds\\ticket_704\\VS2005\\gridlabd-2_0.xsl\" type=\"text/xsl\"?>\n");
 	fprintf(fn,"<gridlabd>\n");
 	//write time
 	gl_printtime(t, timestr, 64);
@@ -149,10 +149,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<fuse>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -415,10 +418,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<overhead_line>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -684,10 +690,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<recloser>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -950,10 +959,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<regulator>\n");
 
 			//write the name
-			if(obj->name != NULL){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -1220,10 +1232,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<relay>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -1486,10 +1501,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<sectionalizer>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -1752,10 +1770,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<series reactor>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -2019,10 +2040,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<switch>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -2285,10 +2309,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<transformer>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -2569,10 +2596,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<triplex_line>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -2811,10 +2841,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<underground_line>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n", obj->oclass->name, obj->id);
 			}
 
 			//write the id
@@ -3079,10 +3112,13 @@ int impedance_dump::dump(TIMESTAMP t)
 			fprintf(fn,"\t<capacitor>\n");
 
 			//write the name
-			if(obj->name[0] != 0){
+			if ( obj->name && strlen(obj->name) > 0 )
+			{
 				fprintf(fn,"\t\t<name>%s</name>\n",obj->name);
-			} else {
-				fprintf(fn,"\t\t<name>NA</name>\n");
+			} 
+			else 
+			{
+				fprintf(fn,"\t\t<name>%s:%d</name>\n",obj->oclass->name,obj->id);
 			}
 
 			//write the id
@@ -3228,7 +3264,7 @@ EXPORT int init_impedance_dump(OBJECT *obj)
 	}
 	catch (const char *msg)
 	{
-		gl_error("%s (impedance_dump:%d): %s", obj->name, obj->id, msg);
+		gl_error("%s (impedance_dump:%d): %s", obj->name && strlen(obj->name) > 0 ? obj->name : "(NA)", obj->id, msg);
 		return 0; 
 	}
 }

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -435,6 +435,7 @@ DEPRECATED static struct s_varmap {
 #endif
 	{"streaming_io",PT_bool, &global_streaming_io_enabled, PA_PROTECTED, "streaming I/O enable flag"},
 	{"compileonly",PT_bool, &global_compileonly, PA_PROTECTED, "compile only enable flag"},
+	{"initializeonly",PT_bool, &global_initializeonly, PA_PROTECTED, "initialize only enable flag"},
 	{"relax_naming_rules",PT_bool,&global_relax_naming_rules, PA_PUBLIC, "relax object naming rules enable flag"},
 	{"browser", PT_char1024, &global_browser, PA_PUBLIC, "browser selection"},
 	{"server_portnum",PT_int32,&global_server_portnum, PA_PUBLIC, "server port number (default is find first open starting at 6267)"},


### PR DESCRIPTION
- [x] Fix incorrect `obj->name` usage in power flow dump methods
- [x] Add `initializeonly` global variable, per documentation
- [x] Fix errors in `initializeonly` documentation