### PR TITLE
Develop deprecate ubuntu 20

### DIFF
--- a/.github/workflows/develop-image.yml
+++ b/.github/workflows/develop-image.yml
@@ -111,47 +111,10 @@ jobs:
         gridlabd python -m pip install awscli
         sudo sh ./build.sh --upload --release
 
-  buildUbuntu20FastS3:
-
-    runs-on: ubuntu-20.04
-    environment: Integration
-    container:
-      image: ubuntu:focal
-
-    steps:
-      # this is to fix GIT not liking owner of the checkout dir
-    - name: Set ownership and prep container
-      run: |
-        mkdir -p /usr/local/var
-        apt-get update && apt-get install -y apt-transport-https
-        apt-get install -y git curl nano sudo zip
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
-
-    - uses: actions/checkout@v3
-
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
-
-    - name: Deploy to S3
-      run: |
-        sudo aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY }} && sudo aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} && sudo aws configure set default.region ${{ secrets.AWS_REGION }}
-        export GIT_DISCOVERY_ACROSS_FILESYSTEM=1
-        chown -R root $PWD
-        sudo sh ./setup.sh --local
-        sudo sh ./build.sh --system --parallel
-        gridlabd python -m pip install awscli
-        sudo sh ./build.sh --upload --release
-
   buildAWSUbuntuAMI:
     runs-on: ubuntu-22.04
     environment: Integration
-    needs: [buildUbuntu22FastS3,buildUbuntu20FastS3,buildMacos12FastS3,buildMacos13FastS3]
+    needs: [buildUbuntu22FastS3,buildMacos12FastS3,buildMacos13FastS3]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/master-image.yml
+++ b/.github/workflows/master-image.yml
@@ -111,47 +111,10 @@ jobs:
         gridlabd python -m pip install awscli
         sudo sh ./build.sh --upload --release
 
-  buildUbuntu20FastS3:
-
-    runs-on: ubuntu-20.04
-    environment: Integration
-    container:
-      image: ubuntu:focal
-
-    steps:
-      # this is to fix GIT not liking owner of the checkout dir
-    - name: Set ownership and prep container
-      run: |
-        mkdir -p /usr/local/var
-        apt-get update && apt-get install -y apt-transport-https
-        apt-get install -y git curl nano sudo zip
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
-
-    - uses: actions/checkout@v3
-
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
-
-    - name: Deploy to S3
-      run: |
-        sudo aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY }} && sudo aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} && sudo aws configure set default.region ${{ secrets.AWS_REGION }}
-        export GIT_DISCOVERY_ACROSS_FILESYSTEM=1
-        chown -R root $PWD
-        sudo sh ./setup.sh --local
-        sudo sh ./build.sh --system --parallel
-        gridlabd python -m pip install awscli
-        sudo sh ./build.sh --upload --release
-
   buildAWSUbuntuAMI:
     runs-on: ubuntu-22.04
     environment: Integration
-    needs: [buildUbuntu22FastS3,buildUbuntu20FastS3,buildMacos12FastS3]
+    needs: [buildUbuntu22FastS3,buildMacos12FastS3]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR deprecated Ubuntu 20 support, as the latest required packages are no longer offered on Ubuntu 20.

[x] - Removes Ubuntu 20 from the develop-images and master-images workflows.