### PR TITLE
re-enabled CF invalidations for workflows, changed http back to https…

### DIFF
--- a/.github/workflows/develop-image.yml
+++ b/.github/workflows/develop-image.yml
@@ -38,9 +38,9 @@ jobs:
         aws s3 sync ./cloud/websites/status.arras.energy/ s3://status-dev.arras.energy --acl public-read
         aws s3 sync ./cloud/websites/tutorials.arras.energy/ s3://tutorials-dev.arras.energy --acl public-read
         aws s3 sync ./cloud/websites/www.arras.energy/ s3://www-dev.arras.energy --acl public-read
-# re-enable when buckets live and cloudfront added
-#    - name: Run CF invalidation
-#      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DEV_CF_ID }} --paths '/*'
+
+    - name: Run CF invalidation
+      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DEV_CF_ID }} --paths '/*'
 
   buildMacos13FastS3:
 
@@ -238,8 +238,8 @@ jobs:
         role-session-name: developDockerhubDeploymentWorkflow
         aws-region: ${{ secrets.AWS_REGION }}
 
-#    - name: Run CF invalidation
-#      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DEV_CF_ID }} --paths '/*'
+    - name: Run CF invalidation
+      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DEV_CF_ID }} --paths '/*'
 
     - name: Login to DockerHub
       uses: docker/login-action@v3
@@ -275,8 +275,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ secrets.AWS_REGION }}
 
-#    - name: Run CF invalidation
-#      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DEV_CF_ID }} --paths '/*'
+    - name: Run CF invalidation
+      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DEV_CF_ID }} --paths '/*'
 
     - name: Set output
       run: |

--- a/.github/workflows/master-image.yml
+++ b/.github/workflows/master-image.yml
@@ -39,8 +39,8 @@ jobs:
         aws s3 sync ./cloud/websites/tutorials.arras.energy/ s3://tutorials.arras.energy --acl public-read
         aws s3 sync ./cloud/websites/www.arras.energy/ s3://www.arras.energy --acl public-read
 
-#    - name: Run CF invalidation
-#      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_CF_ID }} --paths '/*'
+    - name: Run CF invalidation
+      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_CF_ID }} --paths '/*'
 
   buildMacos13FastS3:
 
@@ -240,8 +240,8 @@ jobs:
         role-session-name: masterDockerhubDeploymentWorkflow
         aws-region: ${{ secrets.AWS_REGION }}
 
-#    - name: Run CF invalidation
-#      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_CF_ID }} --paths '/*'
+    - name: Run CF invalidation
+      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_CF_ID }} --paths '/*'
 
     - name: Set output
       run: |
@@ -281,8 +281,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ secrets.AWS_REGION }}
 
-#    - name: Run CF invalidation
-#      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_CF_ID }} --paths '/*'
+    - name: Run CF invalidation
+      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_CF_ID }} --paths '/*'
 
     - name: Set output
       run: |

--- a/docker/packer/Dockerfile.dev.ul
+++ b/docker/packer/Dockerfile.dev.ul
@@ -14,11 +14,11 @@ WORKDIR /app/gridlabd
 # Copy the contents of the local directory to the app directory in the container
 COPY . /app/gridlabd
 
-ENV INSTALL_SOURCE=http://install-dev.arras.energy
+ENV INSTALL_SOURCE=https://install-dev.arras.energy
 
 EXPOSE 6266-6299/tcp
 # Run the install.sh script with the desired arguments
-RUN curl -sL http://install-dev.arras.energy/install.sh | sh
+RUN curl -sL https://install-dev.arras.energy/install.sh | sh
 
 RUN gridlabd --version=all
 

--- a/docker/packer/Dockerfile.prod.ul
+++ b/docker/packer/Dockerfile.prod.ul
@@ -14,11 +14,11 @@ WORKDIR /app/gridlabd
 # Copy the contents of the local directory to the app directory in the container
 COPY . /app/gridlabd
 
-ENV INSTALL_SOURCE=http://install.arras.energy
+ENV INSTALL_SOURCE=https://install.arras.energy
 
 EXPOSE 6266-6299/tcp
 # Run the install.sh script with the desired arguments
-RUN curl -sL http://install.arras.energy/install.sh | sh
+RUN curl -sL https://install.arras.energy/install.sh | sh
 
 RUN gridlabd --version=all
 

--- a/docker/packer/templateDevelop.pkr.hcl
+++ b/docker/packer/templateDevelop.pkr.hcl
@@ -68,8 +68,8 @@ build {
       "sudo apt-get update && sudo apt-get install -y apt-transport-https",
       "sudo apt-get install -y git curl nano",
       "cd /usr/local/src",
-      "export INSTALL_SOURCE=http://install-dev.arras.energy",
-      "curl -sL http://install-dev.arras.energy/install.sh | sudo -E sh",
+      "export INSTALL_SOURCE=https://install-dev.arras.energy",
+      "curl -sL https://install-dev.arras.energy/install.sh | sudo -E sh",
       "sudo chown -R $USER /usr/local",
       "gridlabd --version=all"
     ]


### PR DESCRIPTION
Simple update.

Buckets are live with CloudFront active. DNS routes use cloudfront, so caching invalidations are needed again.

CloudFront re-enabled HTTPS, so I updated items I had changed to HTTP back to HTTPS. (I set cloudfront to automatically redirect, so it wasn't really necessary, but I like to keep the habit)