### PR TITLE
Fix powerplant cost units and add county attribute

### DIFF
--- a/module/pypower/powerplant.cpp
+++ b/module/pypower/powerplant.cpp
@@ -29,6 +29,9 @@ powerplant::powerplant(MODULE *module)
 			PT_char32, "city", get_city_offset(),
 				PT_DESCRIPTION, "City in which powerplant is located",
 			
+			PT_char32, "county", get_county_offset(),
+				PT_DESCRIPTION, "County in which powerplant is located",
+			
 			PT_char32, "state", get_state_offset(),
 				PT_DESCRIPTION, "State in which powerplant is located",
 			
@@ -59,6 +62,7 @@ powerplant::powerplant(MODULE *module)
 			    PT_KEYWORD, "CT", (set)GT_COMBUSTIONTURBINE,
 			    PT_KEYWORD, "PV", (set)GT_PHOTOVOLTAIC,
 			    PT_KEYWORD, "CC", (set)GT_COMBINEDCYCLE,
+			    PT_KEYWORD, "CS", (set)GT_CONCENTRATEDSOLAR,
 				PT_DESCRIPTION, "Generator type",
 
 			PT_set, "fuel", get_fuel_offset(), 
@@ -122,11 +126,11 @@ powerplant::powerplant(MODULE *module)
 			PT_char256, "controller", get_controller_offset(),
 				PT_DESCRIPTION, "controller python function name",
 
-			PT_double, "startup_cost[$/MW]", get_startup_cost_offset(),
-				PT_DESCRIPTION, "generator startup cost ($/MW)",
+			PT_double, "startup_cost[$]", get_startup_cost_offset(),
+				PT_DESCRIPTION, "generator startup cost ($)",
 
-			PT_double, "shutdown_cost[$/MW]", get_shutdown_cost_offset(),
-				PT_DESCRIPTION, "generator shutdown cost ($/MW)",
+			PT_double, "shutdown_cost[$]", get_shutdown_cost_offset(),
+				PT_DESCRIPTION, "generator shutdown cost ($)",
 
 			PT_double, "fixed_cost[$/h]", get_fixed_cost_offset(),
 				PT_DESCRIPTION, "generator fixed cost ($/h)",
@@ -193,41 +197,43 @@ int powerplant::create(void)
 int powerplant::init(OBJECT *parent_hdr)
 {
 	gen *parent = (gen*)get_parent();
-	if ( parent ) 
+	if ( parent == NULL ) 
 	{
-		if ( parent->isa("gen","pypower") )
+		error("powerplant must have a bus or gen parent");
+		return 0;
+	}
+	if ( parent->isa("gen","pypower") )
+	{
+		is_dynamic = TRUE;
+		parent->add_powerplant(this);
+		if ( get_storage_capacity() > 0 )
 		{
-			is_dynamic = TRUE;
-			parent->add_powerplant(this);
-			if ( get_storage_capacity() > 0 )
-			{
-				warning("energy storage devices cannot be dynamically dispatchable (parent is a generator)");
-			}
+			warning("energy storage devices cannot be dynamically dispatchable (parent is a generator)");
 		}
-		else if ( parent->isa("bus","pypower") )
-		{
-			is_dynamic = FALSE;
-		}
-		else
-		{
-			error("parent '%s' is not a pypower bus or gen object",get_parent()->get_name());
-			return 0;
-		}
+	}
+	else if ( parent->isa("bus","pypower") )
+	{
+		is_dynamic = FALSE;
+	}
+	else
+	{
+		error("parent '%s' is not a pypower bus or gen object",get_parent()->get_name());
+		return 0;
+	}
 
-		// look for gencost object that corresponds to this generator (if any)
-		for ( OBJECT *obj = gl_object_get_first() ; obj != NULL ; obj = obj->next)
+	// look for gencost object that corresponds to this generator (if any)
+	for ( OBJECT *obj = gl_object_get_first() ; obj != NULL ; obj = obj->next)
+	{
+		if ( gl_object_isa(obj,"gencost","pypower") )
 		{
-			if ( gl_object_isa(obj,"gencost","pypower") )
+			costobj = OBJECTDATA(obj,gencost);
+			if ( costobj->get_parent() == parent )
 			{
-				costobj = OBJECTDATA(obj,gencost);
-				if ( costobj->get_parent() == parent )
-				{
-					break; // got it
-				}
-				else
-				{
-					costobj = NULL; // forget about it!
-				}
+				break; // got it
+			}
+			else
+			{
+				costobj = NULL; // forget about it!
 			}
 		}
 	}
@@ -282,7 +288,7 @@ int powerplant::init(OBJECT *parent_hdr)
 	PyDict_SetItemString(py_kwargs,"substation_2",PyUnicode_FromString(get_substation_2()));
 	Py_complex z = {get_S().Re(), get_S().Im()};
 	PyDict_SetItemString(py_kwargs,"S",PyComplex_FromCComplex(z));
-	if ( get_parent() && get_parent()->isa("bus","pypower") )
+	if ( get_parent()->isa("bus","pypower") )
 	{
 		bus *parent = (bus*)get_parent();
 		PyDict_SetItemString(py_kwargs,"Vm",PyFloat_FromDouble(parent->get_Vm()));

--- a/module/pypower/powerplant.h
+++ b/module/pypower/powerplant.h
@@ -25,6 +25,7 @@ public:
 		GT_COMBUSTIONTURBINE 	= 0x0100,
 		GT_PHOTOVOLTAIC			= 0x0200,
 		GT_COMBINEDCYCLE		= 0x0400,
+		GT_CONCENTRATEDSOLAR	= 0x0800,
 	} GENERATORTYPE;
 
 	typedef enum {
@@ -55,6 +56,7 @@ public:
 public:
 	// published properties
 	GL_ATOMIC(char32,city);
+	GL_ATOMIC(char32,county);
 	GL_ATOMIC(char32,state);
 	GL_ATOMIC(char32,zipcode);
 	GL_ATOMIC(char32,country);


### PR DESCRIPTION
This update fixes an issue with how generation costs are computed in the pypower module. Also adds the `county` field to the powerplant object.

# Tasks completed

- [x] Fix cost units
- [x] Add county name